### PR TITLE
Reduce memory allocations and improve speed of html parsing

### DIFF
--- a/opengraph/opengraph_test.go
+++ b/opengraph/opengraph_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/dyatlov/go-opengraph/opengraph"
 )
 
-func TestOpenGraphProcessHTML(t *testing.T) {
-	html := `
+const html = `
   <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
 <head profile="http://gmpg.org/xfn/11">
@@ -31,6 +30,19 @@ func TestOpenGraphProcessHTML(t *testing.T) {
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:creator" content="@WordPress" />
   `
+
+func BenchmarkOpenGraph_ProcessHTML(b *testing.B) {
+	og := opengraph.NewOpenGraph()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(html)))
+	for i := 0; i < b.N; i++ {
+		if err := og.ProcessHTML(strings.NewReader(html)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestOpenGraphProcessHTML(t *testing.T) {
 	og := opengraph.NewOpenGraph()
 	err := og.ProcessHTML(strings.NewReader(html))
 


### PR DESCRIPTION
Reduce memory allocations and imporve speed of html parsing by using low-level html.Tokenizer in ProcessHTML method.

```
name                     old time/op    new time/op    delta
OpenGraph_ProcessHTML-4    54.2µs ± 1%    31.5µs ± 2%  -41.84%  (p=0.008 n=5+5)

name                     old speed      new speed      delta
OpenGraph_ProcessHTML-4  24.3MB/s ± 1%  41.8MB/s ± 2%  +71.96%  (p=0.008 n=5+5)

name                     old alloc/op   new alloc/op   delta
OpenGraph_ProcessHTML-4    13.6kB ± 0%     5.9kB ± 0%  -57.05%  (p=0.008 n=5+5)

name                     old allocs/op  new allocs/op  delta
OpenGraph_ProcessHTML-4       175 ± 0%        52 ± 0%  -70.29%  (p=0.008 n=5+5)
```
