### PR TITLE
Add Charset field to the OpenGraph struct

### DIFF
--- a/opengraph/opengraph.go
+++ b/opengraph/opengraph.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/net/html"
@@ -66,6 +67,7 @@ type OpenGraph struct {
 	isArticle        bool
 	isBook           bool
 	isProfile        bool
+	Charset          string   `json:"charset"`
 	Type             string   `json:"type"`
 	URL              string   `json:"url"`
 	Title            string   `json:"title"`
@@ -124,9 +126,20 @@ func (og *OpenGraph) ProcessHTML(buffer io.Reader) error {
 			}
 			m := make(map[string]string)
 			var key, val []byte
+			var hasMIME bool
 			for hasAttr {
 				key, val, hasAttr = z.TagAttr()
-				m[atom.String(key)] = string(val)
+				keyString, valString := atom.String(key), string(val)
+				m[keyString] = string(valString)
+				if keyString == "charset" {
+					og.Charset = valString
+				}
+				if keyString == "http-equiv" && strings.EqualFold(valString, "content-type") {
+					hasMIME = true
+				}
+			}
+			if hasMIME {
+				og.processCharsetMetaForHTML4(m)
 			}
 			og.ProcessMeta(m)
 		}
@@ -325,5 +338,14 @@ func (og *OpenGraph) processProfileMeta(metaAttrs map[string]string) {
 		og.Profile.Username = metaAttrs["content"]
 	case "profile:gender":
 		og.Profile.Gender = metaAttrs["content"]
+	}
+}
+
+func (og *OpenGraph) processCharsetMetaForHTML4(metaAttrs map[string]string) {
+	contentType := metaAttrs["content"]
+	const key = "charset="
+	if i := strings.Index(contentType, key); i > 0 {
+		charset := contentType[i+len(key):]
+		og.Charset = strings.TrimRight(charset, " ")
 	}
 }

--- a/opengraph/opengraph_test.go
+++ b/opengraph/opengraph_test.go
@@ -12,7 +12,7 @@ const html = `
   <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
 <head profile="http://gmpg.org/xfn/11">
-<meta charset="utf-8" />
+<meta http-equiv="content-type" content="text/html; charset=windows-1250">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>WordPress &#8250;   WordPress 4.3 &#8220;Billie&#8221;</title>
 
@@ -48,6 +48,10 @@ func TestOpenGraphProcessHTML(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if len(og.Charset) == 0 {
+		t.Error("charset parsed incorrectly")
 	}
 
 	if og.Type != "article" {


### PR DESCRIPTION
Again! 👋 @dyatlov 

Ref: https://github.com/mattermost/mattermost-server/issues/8341

I want an ability to force the opengraph information to be encoded as utf-8. so I just added to charset field for it.

Please check my PR, or let me know if you have any better suggestion.

Thank you :)